### PR TITLE
refs#2 fix for: Konami code overlaps with jump to top button on mobil

### DIFF
--- a/src/components/ToTopArrow.astro
+++ b/src/components/ToTopArrow.astro
@@ -15,29 +15,35 @@ import { Icon } from "astro-icon/components";
   </style>
 
   <script>
-    const toTopButton = document.querySelector<HTMLElement>(".to-top");
+    document.addEventListener("DOMContentLoaded", () => {
+      const toTopButton = document.querySelector<HTMLElement>(".to-top");
 
-    document.addEventListener("scroll", () => {
-      if (!toTopButton) {
-        return;
-      }
-      if (window.scrollY > 250) {
-        toTopButton.style.opacity = "1";
-      } else {
-        toTopButton.style.opacity = "0";
-      }
+      if (!toTopButton) return;
+
+      const handleScroll = () => {
+        const isScrolledToBottom = (window.innerHeight + window.scrollY) >= (document.documentElement.scrollHeight - 1);
+        const isMobile = window.innerWidth <= 768;
+
+        if (window.scrollY > 250) {
+          toTopButton.style.opacity = "1";
+        } else {
+          toTopButton.style.opacity = "0";
+        }
+
+        if (isScrolledToBottom && isMobile) {
+          toTopButton.style.marginBottom = "50px";
+        } else {
+          toTopButton.style.marginBottom = "0";
+        }
+      };
+
+      document.addEventListener("scroll", handleScroll);
+
+      toTopButton.addEventListener("click", () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      });
+
+      handleScroll();
     });
-
-    toTopButton?.addEventListener("click", () => {
-      window.scrollTo(0, 0);
-    });
-
-    if (toTopButton) {
-      if (window.scrollY > 250) {
-        toTopButton.style.opacity = "1";
-      } else {
-        toTopButton.style.opacity = "0";
-      }
-    }
-  </script></button
->
+  </script>
+</button>


### PR DESCRIPTION
This is the fix for To-Top Arrow overlapping issues in mobile responsive views.

I've conditionally added margin-bottom and also i've added the condition to run that code efficiently.

<img width="415" alt="Screenshot 2024-05-17 at 3 32 09 PM" src="https://github.com/FujoWebDev/fujocoded/assets/84974169/c958baf4-60da-4255-9756-7640e3c6ef90">
